### PR TITLE
v0.4.0 [Refactor] Settle Attention API Behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,32 @@ All notable changes to this project will be documented in this file.
 
 This project follows [Semantic Versioning](https://semver.org/).
 
+## [0.4.0] - 2026-07-25
+
+### Added
+
+- Enhanced cross-attention support by allowing query length to differ from the
+  key and value lengths.
+- Added support for 4D attention masks that broadcast across heads.
+
+### Changed
+
+- Replaced `use_mask` with `is_causal`, separating causal masking from
+  supplied attention masks.
+- Renamed the forward mask argument to `attn_mask`.
+- Applied supplied attention masks independently of causal masking and combined
+  both restrictions when they are used together.
+- Kept supported masks in broadcastable shapes instead of expanding them
+  across every batch and head.
+- Tightened shape validation for query, key, value, and attention masks.
+
+### Fixed
+
+- Returned zeros for fully masked query rows in the `einsum` backend instead
+  of NaNs.
+- Added validation for mismatched or incorrectly shaped query, key, and value
+  tensors instead of relying on PyTorch to reject them.
+
 ## [0.3.0] - 2026-07-15
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -29,9 +29,44 @@ Use `backend="einsum"` when attention weights are needed. Use `backend="sdpa"`
 to delegate to PyTorch's optimized scaled dot-product attention implementation
 when weights are not needed.
 
+## Supported Tensor and mask shapes
+
+`ScaledDotProductAttention` expects query, key, and value tensors with the
+attention heads already split:
+
+```text
+query: [batch_size, num_heads, num_queries, head_dim]
+key:   [batch_size, num_heads, num_keys, head_dim]
+value: [batch_size, num_heads, num_keys, head_dim]
+```
+
+The query and key lengths can differ, so the same module works for both
+self-attention and cross-attention. But, ey and value lengths must match. Batch
+size, head count, and head dimension must match across all three tensors.
+
+For now, attention masks must use `torch.bool`. `True` marks a position that
+should be masked out, while `False` marks a position that can be attended to.
+The supported mask shapes are:
+
+- `[num_queries, num_keys]`
+- `[batch_size, num_queries, num_keys]`
+- `[batch_size, 1, num_queries, num_keys]`
+- `[batch_size, num_heads, num_queries, num_keys]`
+
+The smaller forms broadcast across batches or heads. When `is_causal=True`, a
+supplied mask is applied together with the causal mask. If every key is masked
+for a query, its output is zero. The `einsum` backend also returns zero
+attention weights for that query.
+
 ## Project status
 
 ADLERS is in a very early stage. I'm just trying to build the attention mechanism
 library I wish existed while I was working on my thesis, one that had readable
 implementations, consistent APIs, and readily available benchmarks with optimized
 PyTorch kernels.
+
+*Notes*:
+
+- A `MultiHeadAttention`-style class is not yet implemented for this project, and
+will probably be added once we have a decent collection of attention mechanisms.
+- I'll add support for float masks later on.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "adlers"
-version = "0.3.0"
+version = "0.4.0"
 description = "A unified package for PyTorch-based attention mechanisms from across domains"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/adlers/shared/_attention_base.py
+++ b/src/adlers/shared/_attention_base.py
@@ -172,7 +172,7 @@ class AttentionBase(nn.Module, ABC):
         # Short-hand notations for shapes
         Bq, Hq, Lq, Dhq = query.shape
         Bk, Hk, Lk, Dhk = key.shape
-        Bv, Hv, _, Dhv = value.shape
+        Bv, Hv, Lv, Dhv = value.shape
 
         if not (Bq == Bk == Bv):
             raise ValueError(
@@ -187,6 +187,12 @@ class AttentionBase(nn.Module, ABC):
             raise ValueError(
                 "Attention heads dimension mismatch between Queries, Keys, "
                 "Values, tensors."
+            )
+        if Lk != Lv:
+            raise ValueError(
+                "Key and value sequence lengths must match; "
+                f"got key length {Lk} and value length {Lv}. "
+                "Provide one value position for each key position."
             )
 
         if attn_mask is not None and attn_mask.shape not in [

--- a/src/adlers/shared/_attention_base.py
+++ b/src/adlers/shared/_attention_base.py
@@ -10,8 +10,8 @@ class AttentionBase(nn.Module, ABC):
     Base class for all attention modules in this package.
 
     Args:
-        use_mask (bool): Whether forward() should expect and (even if not
-            provided) apply an attention mask.
+        is_causal (bool): Whether to prevent queries from attending to future
+            key positions.
         dropout_rate (float): Dropout rate.
         output_attention_scores (bool): Whether forward() should return
             attention weights.
@@ -24,14 +24,14 @@ class AttentionBase(nn.Module, ABC):
 
     def __init__(
         self,
-        use_mask: bool = False,
+        is_causal: bool = False,
         dropout_rate: float = 0.0,
         output_attention_scores: bool = False,
         strict_mode: bool = True,
         custom_scale_factor: float | None = None,
     ) -> None:
         super().__init__()
-        self.use_mask = use_mask
+        self.is_causal = is_causal
         self.dropout = (
             nn.Dropout(dropout_rate) if dropout_rate > 0 else nn.Identity()
         )
@@ -44,7 +44,7 @@ class AttentionBase(nn.Module, ABC):
         query: Tensor,
         key: Tensor,
         value: Tensor,
-        mask: Tensor | None = None,
+        attn_mask: Tensor | None = None,
     ) -> tuple[Tensor, Tensor | None]:
         """
         Forward method inherited by all child classes of AttentionBase.
@@ -59,7 +59,7 @@ class AttentionBase(nn.Module, ABC):
                 num_keys, head_dim].
             value (Tensor): Value tensor of shape [batch_size, num_heads,
                 num_values, head_dim].
-            mask (Tensor): Boolean attention mask tensor of either:
+            attn_mask (Tensor): Boolean attention mask tensor of either:
                 a 2D shape of [num_queries, num_keys],
                 a 3D shape of [batch_size, num_queries, num_keys], or
                 a 4D shape of [batch_size, num_heads, num_queries, num_keys].
@@ -73,10 +73,12 @@ class AttentionBase(nn.Module, ABC):
             attn_weights (Optional[Tensor]): Attention weights tensor of shape
                 [batch_size, num_heads, num_queries, num_keys].
         """
-        # Adjust mask shape if mask should be used and is provided
-        if self.use_mask and mask is not None:
-            mask = self._normalize_mask(
-                mask=mask, batch_size=query.shape[0], num_heads=query.shape[1]
+        if attn_mask is not None:
+            self._validate_attn_mask_dtype(attn_mask=attn_mask)
+            attn_mask = self._normalize_attn_mask(
+                attn_mask=attn_mask,
+                batch_size=query.shape[0],
+                num_heads=query.shape[1],
             )
 
         # Generate scale factor if not provided
@@ -88,7 +90,12 @@ class AttentionBase(nn.Module, ABC):
 
         # Validate input shapes if using strict mode
         if self.strict_mode:
-            self._validate_shapes(query=query, key=key, value=value, mask=mask)
+            self._validate_shapes(
+                query=query,
+                key=key,
+                value=value,
+                attn_mask=attn_mask,
+            )
 
         # Core computations
         attn_output, attn_weights = self._attend(
@@ -96,7 +103,7 @@ class AttentionBase(nn.Module, ABC):
             key=key,
             value=value,
             scale_factor=scale_factor,
-            mask=mask,
+            attn_mask=attn_mask,
         )
 
         return (
@@ -112,7 +119,7 @@ class AttentionBase(nn.Module, ABC):
         key: Tensor,
         value: Tensor,
         scale_factor: float,
-        mask: Tensor | None,
+        attn_mask: Tensor | None,
     ) -> tuple[Tensor, Tensor | None]:
         """
         Core attention method that will be overriden in subclasses.
@@ -125,10 +132,10 @@ class AttentionBase(nn.Module, ABC):
             value (Tensor): Value tensor of shape [batch_size, num_heads,
                 num_values, head_dim].
             scale_factor (float): Scale factor to multiply raw scores by.
-            mask (Tensor): Boolean attention mask tensor of shape [batch_size,
-                num_heads, num_queries, num_keys]. True marks positions that
-                should be masked out, and False marks positions that can be
-                attended to.
+            attn_mask (Tensor): Boolean attention mask tensor of shape
+                [batch_size, num_heads, num_queries, num_keys]. True marks
+                positions that should be masked out, and False marks positions
+                that can be attended to.
 
         Returns:
             attn_output (Tensor): Attention output tensor of shape [batch_size,
@@ -143,7 +150,7 @@ class AttentionBase(nn.Module, ABC):
         query: Tensor,
         key: Tensor,
         value: Tensor,
-        mask: Tensor | None,
+        attn_mask: Tensor | None,
     ) -> None:
         """
         Validates shapes of the Query, Key, Value and optional attention mask
@@ -156,7 +163,7 @@ class AttentionBase(nn.Module, ABC):
                 num_keys, head_dim].
             value (Tensor): Value tensor of shape [batch_size, num_heads,
                 num_values, head_dim].
-            mask (Tensor): Boolean attention mask tensor of either:
+            attn_mask (Tensor): Boolean attention mask tensor of either:
                 a 2D shape of [num_queries, num_keys],
                 a 3D shape of [batch_size, num_queries, num_keys], or
                 a 4D shape of [batch_size, num_heads, num_queries, num_keys].
@@ -186,27 +193,32 @@ class AttentionBase(nn.Module, ABC):
                 "Values, tensors."
             )
 
-        if mask is not None and mask.shape not in [
+        if attn_mask is not None and attn_mask.shape not in [
             (Lq, Lk),
             (Bq, Lq, Lk),
             (Bq, Hq, Lq, Lk),
         ]:
             raise ValueError(
-                f"Invalid mask shape {mask.shape}, expected (num_queries, "
-                "num_keys), (batch_size, num_queries, num_keys), or "
-                "(batch_size, num_heads, num_queries, num_keys)."
-            )
-        if mask is not None and mask.dtype != torch.bool:
-            raise TypeError(
-                "Only boolean attention masks are supported; "
-                f"got mask dtype {mask.dtype}. Use a torch.bool mask with "
-                "True for positions that should be masked out and False for "
-                "positions that can be attended to."
+                f"Invalid mask shape {attn_mask.shape}, expected "
+                "(num_queries, num_keys), (batch_size, num_queries, "
+                "num_keys), or (batch_size, num_heads, num_queries, "
+                "num_keys)."
             )
 
     @staticmethod
-    def _normalize_mask(
-        mask: Tensor,
+    def _validate_attn_mask_dtype(attn_mask: Tensor) -> None:
+        """Validates that an attention mask follows ADLERS semantics."""
+        if attn_mask.dtype != torch.bool:
+            raise TypeError(
+                "Only boolean attention masks are supported; "
+                f"got mask dtype {attn_mask.dtype}. Use a torch.bool mask "
+                "with True for positions that should be masked out and "
+                "False for positions that can be attended to."
+            )
+
+    @staticmethod
+    def _normalize_attn_mask(
+        attn_mask: Tensor,
         batch_size: int,
         num_heads: int,
     ) -> Tensor:
@@ -230,7 +242,7 @@ class AttentionBase(nn.Module, ABC):
         num_keys].
 
         Args:
-            mask (Tensor): Boolean attention mask tensor of either:
+            attn_mask (Tensor): Boolean attention mask tensor of either:
                 a 2D shape of [num_queries, num_keys],
                 a 3D shape of [batch_size, num_queries, num_keys], or
                 a 4D shape of [batch_size, num_heads, num_queries, num_keys].
@@ -242,22 +254,54 @@ class AttentionBase(nn.Module, ABC):
                 4D masks to.
 
         Returns:
-            mask (Tensor): Attention mask of shape [batch_size, num_heads,
-                num_queries, num_keys].
+            attn_mask (Tensor): Attention mask of shape [batch_size,
+                num_heads, num_queries, num_keys].
 
         """
-        if mask.dim() == 2:
-            mask = mask.unsqueeze(0).unsqueeze(0)
-            mask = mask.expand(batch_size, num_heads, -1, -1)
-        elif mask.dim() == 3:
-            mask = mask.unsqueeze(1)
-            mask = mask.expand(-1, num_heads, -1, -1)
-        elif mask.dim() == 4:
-            if mask.shape[1] == 1 and num_heads != 1:
-                mask = mask.expand(-1, num_heads, -1, -1)
+        if attn_mask.dim() == 2:
+            attn_mask = attn_mask.unsqueeze(0).unsqueeze(0)
+            attn_mask = attn_mask.expand(batch_size, num_heads, -1, -1)
+        elif attn_mask.dim() == 3:
+            attn_mask = attn_mask.unsqueeze(1)
+            attn_mask = attn_mask.expand(-1, num_heads, -1, -1)
+        elif attn_mask.dim() == 4:
+            if attn_mask.shape[1] == 1 and num_heads != 1:
+                attn_mask = attn_mask.expand(-1, num_heads, -1, -1)
             else:
                 pass
         else:
-            raise ValueError(f"Mask must be 2D, 3D or 4D; got {mask.dim()}D")
+            raise ValueError(
+                "Attention mask must be 2D, 3D or 4D; "
+                f"got {attn_mask.dim()}D."
+            )
 
-        return mask
+        return attn_mask
+
+    def _combine_with_causal_mask(
+        self,
+        query: Tensor,
+        key: Tensor,
+        attn_mask: Tensor | None,
+    ) -> Tensor | None:
+        """Combines an explicit attention mask with causal restrictions."""
+        if not self.is_causal:
+            return attn_mask
+
+        causal_mask = self._make_causal_mask(query=query, key=key)
+        if attn_mask is None:
+            return causal_mask
+
+        return causal_mask | attn_mask
+
+    @staticmethod
+    def _make_causal_mask(query: Tensor, key: Tensor) -> Tensor:
+        """Creates a causal mask for the query and key sequence lengths."""
+        return torch.triu(
+            torch.ones(
+                query.shape[-2],
+                key.shape[-2],
+                dtype=torch.bool,
+                device=query.device,
+            ),
+            diagonal=1,
+        )

--- a/src/adlers/shared/_attention_base.py
+++ b/src/adlers/shared/_attention_base.py
@@ -77,13 +77,6 @@ class AttentionBase(nn.Module, ABC):
             self._validate_attn_mask_dtype(attn_mask=attn_mask)
             attn_mask = self._normalize_attn_mask(attn_mask=attn_mask)
 
-        # Generate scale factor if not provided
-        if self.custom_scale_factor is not None:
-            scale_factor = self.custom_scale_factor
-        else:
-            _, _, _, head_dim = key.shape
-            scale_factor = 1.0 / sqrt(head_dim)
-
         # Validate input shapes if using strict mode
         if self.strict_mode:
             self._validate_shapes(
@@ -92,6 +85,13 @@ class AttentionBase(nn.Module, ABC):
                 value=value,
                 attn_mask=attn_mask,
             )
+
+        # Generate scale factor if not provided
+        if self.custom_scale_factor is not None:
+            scale_factor = self.custom_scale_factor
+        else:
+            _, _, _, head_dim = key.shape
+            scale_factor = 1.0 / sqrt(head_dim)
 
         # Core computations
         attn_output, attn_weights = self._attend(
@@ -169,6 +169,18 @@ class AttentionBase(nn.Module, ABC):
         Returns:
             None.
         """
+        for tensor_name, tensor in (
+            ("Query", query),
+            ("Key", key),
+            ("Value", value),
+        ):
+            if tensor.ndim != 4:
+                raise ValueError(
+                    f"{tensor_name} tensor must be 4D "
+                    "[batch_size, num_heads, sequence_length, head_dim]; "
+                    f"got shape {tuple(tensor.shape)}."
+                )
+
         # Short-hand notations for shapes
         Bq, Hq, Lq, Dhq = query.shape
         Bk, Hk, Lk, Dhk = key.shape

--- a/src/adlers/shared/_attention_base.py
+++ b/src/adlers/shared/_attention_base.py
@@ -75,11 +75,7 @@ class AttentionBase(nn.Module, ABC):
         """
         if attn_mask is not None:
             self._validate_attn_mask_dtype(attn_mask=attn_mask)
-            attn_mask = self._normalize_attn_mask(
-                attn_mask=attn_mask,
-                batch_size=query.shape[0],
-                num_heads=query.shape[1],
-            )
+            attn_mask = self._normalize_attn_mask(attn_mask=attn_mask)
 
         # Generate scale factor if not provided
         if self.custom_scale_factor is not None:
@@ -195,12 +191,12 @@ class AttentionBase(nn.Module, ABC):
 
         if attn_mask is not None and attn_mask.shape not in [
             (Lq, Lk),
-            (Bq, Lq, Lk),
+            (Bq, 1, Lq, Lk),
             (Bq, Hq, Lq, Lk),
         ]:
             raise ValueError(
                 f"Invalid mask shape {attn_mask.shape}, expected "
-                "(num_queries, num_keys), (batch_size, num_queries, "
+                "(num_queries, num_keys), (batch_size, 1, num_queries, "
                 "num_keys), or (batch_size, num_heads, num_queries, "
                 "num_keys)."
             )
@@ -219,59 +215,36 @@ class AttentionBase(nn.Module, ABC):
             )
 
     @staticmethod
-    def _normalize_attn_mask(
-        attn_mask: Tensor,
-        batch_size: int,
-        num_heads: int,
-    ) -> Tensor:
+    def _normalize_attn_mask(attn_mask: Tensor) -> Tensor:
         """
-        Adjusts mask shape from either 2D to 4D or 3D to 4D. Expands to
-        num_heads dimension on a 4D mask if needed.
+        Preserves broadcastable mask shapes for attention operations.
 
-        If given mask dimension == 2, assumes it is [num_queries, num_keys].
-        First it unsqueezes to [1, 1, num_queries, num_keys] and then expands
-        to [batch_size, num_heads, num_queries, num_keys] to match the expected
-        shape of attention scores.
+        A 2D mask of shape [num_queries, num_keys] is kept unchanged and
+        broadcasts across batches and heads.
 
-        If given mask dimension == 3, assumes it is [batch_size, num_queries,
-        num_keys]. First it unsqueezes to [batch_size, 1, num_queries,
-        num_keys] and then expands to [batch_size, num_heads, num_queries,
-        num_keys] to match the expected shape of attention scores.
+        A 3D mask of shape [batch_size, num_queries, num_keys] gains a
+        singleton head dimension so it broadcasts across heads.
 
-        If given mask dimension == 4, and mask's second dimension == 1 but
-        num_heads != 1, assumes mask is provided as [batch_size, 1, num_queries,
-        num_keys] and expands it to [batch_size, num_heads, num_queries,
-        num_keys].
+        A 4D mask is kept unchanged, whether it has a singleton head dimension
+        or a separate mask for each head.
 
         Args:
             attn_mask (Tensor): Boolean attention mask tensor of either:
                 a 2D shape of [num_queries, num_keys],
                 a 3D shape of [batch_size, num_queries, num_keys], or
-                a 4D shape of [batch_size, num_heads, num_queries, num_keys].
+                a 4D shape of [batch_size, 1 or num_heads, num_queries,
+                num_keys].
                 Only torch.bool masks are supported. True marks positions that
                 should be masked out, and False marks positions that can be
                 attended to.
-            batch_size (int): Batch size to expand the 2D masks to.
-            num_heads (int): Number of attention heads to expand the 2D / 3D /
-                4D masks to.
 
         Returns:
-            attn_mask (Tensor): Attention mask of shape [batch_size,
-                num_heads, num_queries, num_keys].
-
+            attn_mask (Tensor): Attention mask with a shape broadcastable to
+                [batch_size, num_heads, num_queries, num_keys].
         """
-        if attn_mask.dim() == 2:
-            attn_mask = attn_mask.unsqueeze(0).unsqueeze(0)
-            attn_mask = attn_mask.expand(batch_size, num_heads, -1, -1)
-        elif attn_mask.dim() == 3:
+        if attn_mask.dim() == 3:
             attn_mask = attn_mask.unsqueeze(1)
-            attn_mask = attn_mask.expand(-1, num_heads, -1, -1)
-        elif attn_mask.dim() == 4:
-            if attn_mask.shape[1] == 1 and num_heads != 1:
-                attn_mask = attn_mask.expand(-1, num_heads, -1, -1)
-            else:
-                pass
-        else:
+        elif attn_mask.dim() not in (2, 4):
             raise ValueError(
                 "Attention mask must be 2D, 3D or 4D; "
                 f"got {attn_mask.dim()}D."

--- a/src/adlers/shared/_attention_base.py
+++ b/src/adlers/shared/_attention_base.py
@@ -208,6 +208,8 @@ class AttentionBase(nn.Module, ABC):
     @staticmethod
     def _validate_attn_mask_dtype(attn_mask: Tensor) -> None:
         """Validates that an attention mask follows ADLERS semantics."""
+        # NOTE: for now only allowing boolean masks, may extend support to
+        # float masks once/if repo is (ever) more mature
         if attn_mask.dtype != torch.bool:
             raise TypeError(
                 "Only boolean attention masks are supported; "

--- a/src/adlers/shared/_attention_base.py
+++ b/src/adlers/shared/_attention_base.py
@@ -188,17 +188,24 @@ class AttentionBase(nn.Module, ABC):
 
         if not (Bq == Bk == Bv):
             raise ValueError(
-                "Batch size mismatch between Queries, Keys, Values tensors."
+                "Query, key, and value batch sizes must match; "
+                f"got query batch size {Bq}, key batch size {Bk}, and "
+                f"value batch size {Bv}. Use the same batch size for all "
+                "three tensors."
             )
         if not (Hq == Hk == Hv):
             raise ValueError(
-                "Attention heads count mismatch between Queries, Keys, Values "
-                "tensors."
+                "Query, key, and value head counts must match; "
+                f"got query head count {Hq}, key head count {Hk}, and "
+                f"value head count {Hv}. Use the same number of heads for "
+                "all three tensors."
             )
         if not (Dhq == Dhk == Dhv):
             raise ValueError(
-                "Attention heads dimension mismatch between Queries, Keys, "
-                "Values, tensors."
+                "Query, key, and value head dimensions must match; "
+                f"got query head dimension {Dhq}, key head dimension {Dhk}, "
+                f"and value head dimension {Dhv}. Use the same head dimension "
+                "for all three tensors."
             )
         if Lk != Lv:
             raise ValueError(

--- a/src/adlers/shared/_attention_base.py
+++ b/src/adlers/shared/_attention_base.py
@@ -59,19 +59,25 @@ class AttentionBase(nn.Module, ABC):
                 num_keys, head_dim].
             value (Tensor): Value tensor of shape [batch_size, num_heads,
                 num_values, head_dim].
-            attn_mask (Tensor): Boolean attention mask tensor of either:
+            attn_mask (Optional[Tensor]): Boolean attention mask tensor of
+                either:
                 a 2D shape of [num_queries, num_keys],
                 a 3D shape of [batch_size, num_queries, num_keys], or
-                a 4D shape of [batch_size, num_heads, num_queries, num_keys].
-                Only torch.bool masks are supported. True marks positions that
-                should be masked out, and False marks positions that can be
-                attended to.
+                a 4D shape of [batch_size, 1 or num_heads, num_queries,
+                num_keys]. Only torch.bool masks are supported. True marks
+                positions that should be masked out, and False marks positions
+                that can be attended to.
 
         Returns:
             attn_output (Tensor): Attention output tensor of shape [batch_size,
                 num_heads, num_queries, head_dim].
             attn_weights (Optional[Tensor]): Attention weights tensor of shape
                 [batch_size, num_heads, num_queries, num_keys].
+
+        Raises:
+            TypeError: If attn_mask is not a torch.bool tensor.
+            ValueError: If the mask rank is unsupported, or if strict mode is
+                enabled and an input shape is invalid.
         """
         if attn_mask is not None:
             self._validate_attn_mask_dtype(attn_mask=attn_mask)
@@ -118,7 +124,7 @@ class AttentionBase(nn.Module, ABC):
         attn_mask: Tensor | None,
     ) -> tuple[Tensor, Tensor | None]:
         """
-        Core attention method that will be overriden in subclasses.
+        Core attention method that will be overridden in subclasses.
 
         Args:
             query (Tensor): Query tensor of shape [batch_size, num_heads,
@@ -128,7 +134,7 @@ class AttentionBase(nn.Module, ABC):
             value (Tensor): Value tensor of shape [batch_size, num_heads,
                 num_values, head_dim].
             scale_factor (float): Scale factor to multiply raw scores by.
-            attn_mask (Tensor): Boolean attention mask tensor of shape
+            attn_mask (Optional[Tensor]): Boolean mask broadcastable to
                 [batch_size, num_heads, num_queries, num_keys]. True marks
                 positions that should be masked out, and False marks positions
                 that can be attended to.
@@ -159,13 +165,14 @@ class AttentionBase(nn.Module, ABC):
                 num_keys, head_dim].
             value (Tensor): Value tensor of shape [batch_size, num_heads,
                 num_values, head_dim].
-            attn_mask (Tensor): Boolean attention mask tensor of either:
+            attn_mask (Optional[Tensor]): Boolean attention mask tensor of
+                either:
                 a 2D shape of [num_queries, num_keys],
                 a 3D shape of [batch_size, num_queries, num_keys], or
-                a 4D shape of [batch_size, num_heads, num_queries, num_keys].
-                Only torch.bool masks are supported. True marks positions that
-                should be masked out, and False marks positions that can be
-                attended to.
+                a 4D shape of [batch_size, 1 or num_heads, num_queries,
+                num_keys]. Only torch.bool masks are supported. True marks
+                positions that should be masked out, and False marks positions
+                that can be attended to.
         Returns:
             None.
         """

--- a/src/adlers/shared/scaled_dot_product.py
+++ b/src/adlers/shared/scaled_dot_product.py
@@ -20,8 +20,8 @@ class ScaledDotProductAttention(AttentionBase):
     should be masked out, and False marks positions that can be attended to.
 
     Args:
-        use_mask (bool): Whether forward() should expect and (even if not
-            provided) apply an attention mask.
+        is_causal (bool): Whether to prevent queries from attending to future
+            key positions.
         dropout_rate (float): Dropout rate.
         output_attention_scores (bool): Whether forward() should return
             attention weights.
@@ -37,7 +37,7 @@ class ScaledDotProductAttention(AttentionBase):
 
     def __init__(
         self,
-        use_mask: bool = False,
+        is_causal: bool = False,
         dropout_rate: float = 0.0,
         output_attention_scores: bool = False,
         strict_mode: bool = True,
@@ -57,7 +57,7 @@ class ScaledDotProductAttention(AttentionBase):
             )
 
         super().__init__(
-            use_mask=use_mask,
+            is_causal=is_causal,
             dropout_rate=dropout_rate,
             output_attention_scores=output_attention_scores,
             strict_mode=strict_mode,
@@ -71,7 +71,7 @@ class ScaledDotProductAttention(AttentionBase):
         key: Tensor,
         value: Tensor,
         scale_factor: float,
-        mask: Tensor | None,
+        attn_mask: Tensor | None,
     ) -> tuple[Tensor, Tensor | None]:
         """
         Routes scaled dot-product attention to the configured backend.
@@ -84,7 +84,7 @@ class ScaledDotProductAttention(AttentionBase):
             value (Tensor): Value tensor of shape [batch_size, num_heads,
                 num_values, head_dim].
             scale_factor (float): Scale factor to multiply raw scores by.
-            mask (Tensor): Attention mask tensor of shape [batch_size,
+            attn_mask (Tensor): Attention mask tensor of shape [batch_size,
                 num_heads, num_queries, num_keys].
 
         Returns:
@@ -99,7 +99,7 @@ class ScaledDotProductAttention(AttentionBase):
                 key=key,
                 value=value,
                 scale_factor=scale_factor,
-                mask=mask,
+                attn_mask=attn_mask,
             )
 
         return self._attend_sdpa(
@@ -107,7 +107,7 @@ class ScaledDotProductAttention(AttentionBase):
             key=key,
             value=value,
             scale_factor=scale_factor,
-            mask=mask,
+            attn_mask=attn_mask,
         )
 
     def _attend_einsum(
@@ -116,7 +116,7 @@ class ScaledDotProductAttention(AttentionBase):
         key: Tensor,
         value: Tensor,
         scale_factor: float,
-        mask: Tensor | None,
+        attn_mask: Tensor | None,
     ) -> tuple[Tensor, Tensor]:
         """
         Computes attention with explicit einsum operations.
@@ -129,7 +129,7 @@ class ScaledDotProductAttention(AttentionBase):
             value (Tensor): Value tensor of shape [batch_size, num_heads,
                 num_values, head_dim].
             scale_factor (float): Scale factor to multiply raw scores by.
-            mask (Tensor): Attention mask tensor of shape [batch_size,
+            attn_mask (Tensor): Attention mask tensor of shape [batch_size,
                 num_heads, num_queries, num_keys].
 
         Returns:
@@ -138,23 +138,16 @@ class ScaledDotProductAttention(AttentionBase):
             attn_weights (Tensor): Attention weights tensor of shape
                 [batch_size, num_heads, num_queries, num_keys].
         """
-        # Short-hand notation for shapes
-        Bq, Hq, Lq, _ = query.shape
-        _, _, Lk, _ = key.shape
-
         # Get raw scores
         scores = torch.einsum("bhle,bhse->bhls", query, key)
 
-        # Apply mask if needed
-        if self.use_mask:
-            if mask is None:
-                mask = torch.triu(
-                    torch.ones(Lq, Lk, dtype=torch.bool, device=query.device),
-                    diagonal=1,
-                )
-                mask = mask.unsqueeze(0).unsqueeze(0).expand(Bq, Hq, Lq, Lk)
-
-            scores.masked_fill_(mask, float("-inf"))
+        combined_mask = self._combine_with_causal_mask(
+            query=query,
+            key=key,
+            attn_mask=attn_mask,
+        )
+        if combined_mask is not None:
+            scores = scores.masked_fill(combined_mask, float("-inf"))
 
         # Get attention scores
         attn_weights = self.dropout(
@@ -172,7 +165,7 @@ class ScaledDotProductAttention(AttentionBase):
         key: Tensor,
         value: Tensor,
         scale_factor: float,
-        mask: Tensor | None,
+        attn_mask: Tensor | None,
     ) -> tuple[Tensor, None]:
         """
         Computes attention with PyTorch's native SDPA implementation.
@@ -189,7 +182,7 @@ class ScaledDotProductAttention(AttentionBase):
             value (Tensor): Value tensor of shape [batch_size, num_heads,
                 num_values, head_dim].
             scale_factor (float): Scale factor to multiply raw scores by.
-            mask (Tensor): Attention mask tensor of shape [batch_size,
+            attn_mask (Tensor): Attention mask tensor of shape [batch_size,
                 num_heads, num_queries, num_keys].
 
         Returns:
@@ -197,11 +190,16 @@ class ScaledDotProductAttention(AttentionBase):
                 num_heads, num_queries, head_dim].
             None: SDPA does not return attention weights.
         """
-        attn_mask = None
-        is_causal = self.use_mask
+        is_causal = self.is_causal
 
-        if self.use_mask and mask is not None:
-            attn_mask = ~mask if mask.dtype == torch.bool else mask
+        if attn_mask is not None:
+            if self.is_causal:
+                causal_mask = self._make_causal_mask(
+                    query=query,
+                    key=key,
+                )
+                attn_mask = attn_mask | causal_mask
+            attn_mask = ~attn_mask
             is_causal = False
 
         dropout_p = (

--- a/src/adlers/shared/scaled_dot_product.py
+++ b/src/adlers/shared/scaled_dot_product.py
@@ -192,6 +192,11 @@ class ScaledDotProductAttention(AttentionBase):
         """
         is_causal = self.is_causal
 
+        # torch does not allow using both causal and a custom mask
+        # https://docs.pytorch.org/docs/main/generated/torch.nn.functional.scaled_dot_product_attention.html
+        # here, if user wants both, we generate the combination ourself and
+        # feed it to F.scaled_dot_product_attention as an explicit custom mask
+        # and is_causal=False
         if attn_mask is not None:
             if self.is_causal:
                 causal_mask = self._make_causal_mask(

--- a/src/adlers/shared/scaled_dot_product.py
+++ b/src/adlers/shared/scaled_dot_product.py
@@ -10,6 +10,10 @@ class ScaledDotProductAttention(AttentionBase):
     """
     Scaled dot-product attention with selectable computation backends.
 
+    Query, key, and value tensors must have shape [batch_size, num_heads,
+    sequence_length, head_dim]. Query and key lengths may differ, but key and
+    value lengths must match.
+
     The "einsum" backend computes attention explicitly with PyTorch tensor
     operations and can return attention weights. The "sdpa" backend delegates
     to torch.nn.functional.scaled_dot_product_attention, which can use
@@ -18,6 +22,8 @@ class ScaledDotProductAttention(AttentionBase):
 
     Attention masks must be torch.bool tensors. True marks positions that
     should be masked out, and False marks positions that can be attended to.
+    Fully masked query rows produce zero outputs. The "einsum" backend also
+    returns zero attention weights for those rows.
 
     Args:
         is_causal (bool): Whether to prevent queries from attending to future
@@ -33,6 +39,9 @@ class ScaledDotProductAttention(AttentionBase):
             weights. The "sdpa" backend delegates to PyTorch's native
             scaled dot-product attention implementation and cannot return
             attention weights.
+
+    Attributes:
+        backend (AttentionBackend): Attention implementation used by forward().
     """
 
     def __init__(
@@ -84,8 +93,8 @@ class ScaledDotProductAttention(AttentionBase):
             value (Tensor): Value tensor of shape [batch_size, num_heads,
                 num_values, head_dim].
             scale_factor (float): Scale factor to multiply raw scores by.
-            attn_mask (Tensor): Attention mask tensor of shape [batch_size,
-                num_heads, num_queries, num_keys].
+            attn_mask (Optional[Tensor]): Boolean mask broadcastable to
+                [batch_size, num_heads, num_queries, num_keys].
 
         Returns:
             attn_output (Tensor): Attention output tensor of shape [batch_size,
@@ -129,8 +138,8 @@ class ScaledDotProductAttention(AttentionBase):
             value (Tensor): Value tensor of shape [batch_size, num_heads,
                 num_values, head_dim].
             scale_factor (float): Scale factor to multiply raw scores by.
-            attn_mask (Tensor): Attention mask tensor of shape [batch_size,
-                num_heads, num_queries, num_keys].
+            attn_mask (Optional[Tensor]): Boolean mask broadcastable to
+                [batch_size, num_heads, num_queries, num_keys].
 
         Returns:
             attn_output (Tensor): Attention output tensor of shape [batch_size,
@@ -187,8 +196,8 @@ class ScaledDotProductAttention(AttentionBase):
             value (Tensor): Value tensor of shape [batch_size, num_heads,
                 num_values, head_dim].
             scale_factor (float): Scale factor to multiply raw scores by.
-            attn_mask (Tensor): Attention mask tensor of shape [batch_size,
-                num_heads, num_queries, num_keys].
+            attn_mask (Optional[Tensor]): Boolean mask broadcastable to
+                [batch_size, num_heads, num_queries, num_keys].
 
         Returns:
             attn_output (Tensor): Attention output tensor of shape [batch_size,

--- a/src/adlers/shared/scaled_dot_product.py
+++ b/src/adlers/shared/scaled_dot_product.py
@@ -146,13 +146,18 @@ class ScaledDotProductAttention(AttentionBase):
             key=key,
             attn_mask=attn_mask,
         )
+        fully_masked_rows = None
         if combined_mask is not None:
+            fully_masked_rows = combined_mask.all(dim=-1, keepdim=True)
             scores = scores.masked_fill(combined_mask, float("-inf"))
+            scores = scores.masked_fill(fully_masked_rows, 0.0)
 
         # Get attention scores
         attn_weights = self.dropout(
             torch.softmax(scale_factor * scores, dim=-1)
         )
+        if fully_masked_rows is not None:
+            attn_weights = attn_weights.masked_fill(fully_masked_rows, 0.0)
 
         # Get attention outputs
         attn_outputs = torch.einsum("bhls,bhsd->bhld", attn_weights, value)

--- a/tests/test_attention_base.py
+++ b/tests/test_attention_base.py
@@ -1,0 +1,29 @@
+import pytest
+import torch
+
+from adlers.shared._attention_base import AttentionBase
+
+
+@pytest.mark.parametrize(
+    ("attn_mask_shape", "expected_shape"),
+    [
+        ((4, 4), (4, 4)),
+        ((2, 4, 4), (2, 1, 4, 4)),
+        ((2, 1, 4, 4), (2, 1, 4, 4)),
+        ((2, 3, 4, 4), (2, 3, 4, 4)),
+    ],
+)
+def test_attention_base_preserves_broadcastable_mask_shapes(
+    attn_mask_shape: tuple[int, ...],
+    expected_shape: tuple[int, ...],
+) -> None:
+    """Checks that mask normalization avoids unnecessary expansion."""
+    attn_mask = torch.zeros(attn_mask_shape, dtype=torch.bool)
+
+    normalized_mask = AttentionBase._normalize_attn_mask(
+        attn_mask=attn_mask,
+        batch_size=2,
+        num_heads=3,
+    )
+
+    assert normalized_mask.shape == expected_shape

--- a/tests/test_attention_base.py
+++ b/tests/test_attention_base.py
@@ -20,10 +20,6 @@ def test_attention_base_preserves_broadcastable_mask_shapes(
     """Checks that mask normalization avoids unnecessary expansion."""
     attn_mask = torch.zeros(attn_mask_shape, dtype=torch.bool)
 
-    normalized_mask = AttentionBase._normalize_attn_mask(
-        attn_mask=attn_mask,
-        batch_size=2,
-        num_heads=3,
-    )
+    normalized_mask = AttentionBase._normalize_attn_mask(attn_mask=attn_mask)
 
     assert normalized_mask.shape == expected_shape

--- a/tests/test_scaled_dot_product.py
+++ b/tests/test_scaled_dot_product.py
@@ -225,6 +225,34 @@ def test_scaled_dot_product_backends_match_with_different_query_and_key_lengths(
     torch.testing.assert_close(out, expected_out)
 
 
+def test_scaled_dot_product_rejects_unequal_key_and_value_lengths(
+    make_qkv: MakeQKV,
+) -> None:
+    """Checks that each key position must have a corresponding value."""
+    query, key, value = make_qkv(
+        batch_size=2,
+        num_heads=4,
+        num_queries=3,
+        num_keys=5,
+    )
+    value = value[..., :-1, :]
+    attention = ScaledDotProductAttention(
+        backend="einsum",
+        strict_mode=True,
+    )
+
+    with pytest.raises(
+        ValueError,
+        match="Key and value sequence lengths must match",
+    ):
+        attention(
+            query=query,
+            key=key,
+            value=value,
+            attn_mask=None,
+        )
+
+
 def test_scaled_dot_product_combines_causal_and_explicit_masks(
     make_qkv: MakeQKV,
 ) -> None:

--- a/tests/test_scaled_dot_product.py
+++ b/tests/test_scaled_dot_product.py
@@ -2,6 +2,7 @@ import pytest
 import torch
 import torch.nn.functional as F
 
+from adlers._typing import AttentionBackend
 from adlers.shared import ScaledDotProductAttention
 from tests._typing import MakeQKV
 
@@ -99,6 +100,50 @@ def test_sdpa_backend_matches_torch_scaled_dot_product_attention(
 
     assert weights is None
     torch.testing.assert_close(out, expected_out)
+
+
+@pytest.mark.parametrize("backend", ["einsum", "sdpa"])
+def test_scaled_dot_product_disables_dropout_during_evaluation(
+    backend: AttentionBackend,
+    make_qkv: MakeQKV,
+) -> None:
+    """Checks that evaluation mode disables dropout for every backend."""
+    query, key, value = make_qkv()
+    output_attention_scores = backend == "einsum"
+    attention_with_dropout = ScaledDotProductAttention(
+        dropout_rate=0.5,
+        backend=backend,
+        output_attention_scores=output_attention_scores,
+    )
+    attention_without_dropout = ScaledDotProductAttention(
+        dropout_rate=0.0,
+        backend=backend,
+        output_attention_scores=output_attention_scores,
+    )
+    attention_with_dropout.eval()
+    attention_without_dropout.eval()
+
+    output, weights = attention_with_dropout(
+        query=query,
+        key=key,
+        value=value,
+        attn_mask=None,
+    )
+    expected_output, expected_weights = attention_without_dropout(
+        query=query,
+        key=key,
+        value=value,
+        attn_mask=None,
+    )
+
+    torch.testing.assert_close(output, expected_output)
+    if output_attention_scores:
+        assert weights is not None
+        assert expected_weights is not None
+        torch.testing.assert_close(weights, expected_weights)
+    else:
+        assert weights is None
+        assert expected_weights is None
 
 
 @pytest.mark.parametrize(

--- a/tests/test_scaled_dot_product.py
+++ b/tests/test_scaled_dot_product.py
@@ -146,6 +146,37 @@ def test_scaled_dot_product_disables_dropout_during_evaluation(
         assert expected_weights is None
 
 
+@pytest.mark.parametrize("backend", ["einsum", "sdpa"])
+def test_scaled_dot_product_supports_cpu_bfloat16_autocast(
+    backend: AttentionBackend,
+    make_qkv: MakeQKV,
+) -> None:
+    """Checks CPU bfloat16 autocast compatibility for every backend."""
+    query, key, value = make_qkv()
+    output_attention_scores = backend == "einsum"
+    attention = ScaledDotProductAttention(
+        backend=backend,
+        output_attention_scores=output_attention_scores,
+    )
+
+    with torch.autocast(device_type="cpu", dtype=torch.bfloat16):
+        output, weights = attention(
+            query=query,
+            key=key,
+            value=value,
+            attn_mask=None,
+        )
+
+    assert output.dtype == torch.bfloat16
+    assert torch.isfinite(output).all()
+    if output_attention_scores:
+        assert weights is not None
+        assert weights.dtype == torch.bfloat16
+        assert torch.isfinite(weights).all()
+    else:
+        assert weights is None
+
+
 @pytest.mark.parametrize(
     "attn_mask_shape",
     [

--- a/tests/test_scaled_dot_product.py
+++ b/tests/test_scaled_dot_product.py
@@ -253,6 +253,48 @@ def test_scaled_dot_product_rejects_unequal_key_and_value_lengths(
         )
 
 
+@pytest.mark.parametrize(
+    ("tensor_name", "tensor_index"),
+    [
+        ("query", 0),
+        ("key", 1),
+        ("value", 2),
+    ],
+)
+def test_scaled_dot_product_rejects_non_four_dimensional_qkv_tensors(
+    tensor_name: str,
+    tensor_index: int,
+    make_qkv: MakeQKV,
+) -> None:
+    """Checks that query, key, and value tensors include all four axes."""
+    tensors = list(
+        make_qkv(
+            batch_size=2,
+            num_heads=1,
+            num_queries=3,
+            num_keys=3,
+            head_dim=6,
+        )
+    )
+    tensors[tensor_index] = tensors[tensor_index].squeeze(dim=1)
+    query, key, value = tensors
+    attention = ScaledDotProductAttention(strict_mode=True)
+
+    with pytest.raises(ValueError) as error:
+        attention(
+            query=query,
+            key=key,
+            value=value,
+            attn_mask=None,
+        )
+
+    assert str(error.value) == (
+        f"{tensor_name.capitalize()} tensor must be 4D "
+        "[batch_size, num_heads, sequence_length, head_dim]; "
+        f"got shape {tuple(tensors[tensor_index].shape)}."
+    )
+
+
 def test_scaled_dot_product_combines_causal_and_explicit_masks(
     make_qkv: MakeQKV,
 ) -> None:

--- a/tests/test_scaled_dot_product.py
+++ b/tests/test_scaled_dot_product.py
@@ -295,6 +295,59 @@ def test_scaled_dot_product_rejects_non_four_dimensional_qkv_tensors(
     )
 
 
+@pytest.mark.parametrize(
+    ("key_shape", "expected_message"),
+    [
+        pytest.param(
+            (1, 4, 5, 6),
+            "Query, key, and value batch sizes must match; got query batch "
+            "size 2, key batch size 1, and value batch size 2. Use the same "
+            "batch size for all three tensors.",
+            id="batch-size",
+        ),
+        pytest.param(
+            (2, 3, 5, 6),
+            "Query, key, and value head counts must match; got query head "
+            "count 4, key head count 3, and value head count 4. Use the same "
+            "number of heads for all three tensors.",
+            id="head-count",
+        ),
+        pytest.param(
+            (2, 4, 5, 5),
+            "Query, key, and value head dimensions must match; got query head "
+            "dimension 6, key head dimension 5, and value head dimension 6. "
+            "Use the same head dimension for all three tensors.",
+            id="head-dimension",
+        ),
+    ],
+)
+def test_scaled_dot_product_rejects_qkv_shape_mismatches(
+    key_shape: tuple[int, int, int, int],
+    expected_message: str,
+    make_qkv: MakeQKV,
+) -> None:
+    """Checks batch size, head count, and head dimension mismatches."""
+    query, _, value = make_qkv(
+        batch_size=2,
+        num_heads=4,
+        num_queries=3,
+        num_keys=5,
+        head_dim=6,
+    )
+    key = torch.randn(key_shape)
+    attention = ScaledDotProductAttention(strict_mode=True)
+
+    with pytest.raises(ValueError) as error:
+        attention(
+            query=query,
+            key=key,
+            value=value,
+            attn_mask=None,
+        )
+
+    assert str(error.value) == expected_message
+
+
 def test_scaled_dot_product_combines_causal_and_explicit_masks(
     make_qkv: MakeQKV,
 ) -> None:

--- a/tests/test_scaled_dot_product.py
+++ b/tests/test_scaled_dot_product.py
@@ -160,6 +160,71 @@ def test_scaled_dot_product_supports_mask_broadcasting(
     torch.testing.assert_close(out, expected_out)
 
 
+def test_scaled_dot_product_backends_match_with_different_query_and_key_lengths(
+    make_qkv: MakeQKV,
+) -> None:
+    """Checks cross-attention with different query and key lengths."""
+    batch_size = 2
+    num_heads = 4
+    num_queries = 3
+    num_keys = 5
+    query, key, value = make_qkv(
+        batch_size=batch_size,
+        num_heads=num_heads,
+        num_queries=num_queries,
+        num_keys=num_keys,
+    )
+    attn_mask = torch.zeros(num_queries, num_keys, dtype=torch.bool)
+    attn_mask[:, -1] = True
+
+    einsum_attention = ScaledDotProductAttention(
+        is_causal=False,
+        dropout_rate=0.0,
+        backend="einsum",
+        output_attention_scores=True,
+        strict_mode=True,
+        custom_scale_factor=None,
+    )
+    sdpa_attention = ScaledDotProductAttention(
+        is_causal=False,
+        dropout_rate=0.0,
+        backend="sdpa",
+        output_attention_scores=False,
+        strict_mode=True,
+        custom_scale_factor=None,
+    )
+
+    expected_out, expected_weights = einsum_attention(
+        query=query,
+        key=key,
+        value=value,
+        attn_mask=attn_mask,
+    )
+    out, weights = sdpa_attention(
+        query=query,
+        key=key,
+        value=value,
+        attn_mask=attn_mask,
+    )
+
+    assert expected_out.shape == (
+        batch_size,
+        num_heads,
+        num_queries,
+        query.shape[-1],
+    )
+    assert expected_weights is not None
+    assert expected_weights.shape == (
+        batch_size,
+        num_heads,
+        num_queries,
+        num_keys,
+    )
+    assert torch.count_nonzero(expected_weights[..., -1]) == 0
+    assert weights is None
+    torch.testing.assert_close(out, expected_out)
+
+
 def test_scaled_dot_product_combines_causal_and_explicit_masks(
     make_qkv: MakeQKV,
 ) -> None:

--- a/tests/test_scaled_dot_product.py
+++ b/tests/test_scaled_dot_product.py
@@ -225,6 +225,56 @@ def test_scaled_dot_product_supports_torch_compile_fullgraph_capture(
         assert expected_weights is None
 
 
+@pytest.mark.filterwarnings(
+    "ignore:`torch[.]jit[.]script_method` is deprecated[.] "
+    "Please switch to `torch[.]compile` or `torch[.]export`[.]:"
+    "DeprecationWarning:torch[.]jit[.]_script"
+)
+@pytest.mark.parametrize("backend", ["einsum", "sdpa"])
+def test_scaled_dot_product_supports_strict_torch_export(
+    backend: AttentionBackend,
+    make_qkv: MakeQKV,
+) -> None:
+    """Checks strict torch.export capture and replay for every backend."""
+    query, key, value = make_qkv(
+        batch_size=2,
+        num_heads=4,
+        num_queries=3,
+        num_keys=5,
+    )
+    attn_mask = torch.zeros(3, 5, dtype=torch.bool)
+    attn_mask[:, -1] = True
+    inputs = {
+        "query": query,
+        "key": key,
+        "value": value,
+        "attn_mask": attn_mask,
+    }
+    output_attention_scores = backend == "einsum"
+    attention = ScaledDotProductAttention(
+        backend=backend,
+        output_attention_scores=output_attention_scores,
+    )
+    exported_program = torch.export.export(
+        mod=attention,
+        args=(),
+        kwargs=inputs,
+        strict=True,
+    )
+
+    expected_output, expected_weights = attention(**inputs)
+    output, weights = exported_program.module()(**inputs)
+
+    torch.testing.assert_close(output, expected_output)
+    if output_attention_scores:
+        assert weights is not None
+        assert expected_weights is not None
+        torch.testing.assert_close(weights, expected_weights)
+    else:
+        assert weights is None
+        assert expected_weights is None
+
+
 @pytest.mark.parametrize(
     "attn_mask_shape",
     [

--- a/tests/test_scaled_dot_product.py
+++ b/tests/test_scaled_dot_product.py
@@ -433,3 +433,48 @@ def test_scaled_dot_product_requires_boolean_mask(
             value=value,
             attn_mask=attn_mask,
         )
+
+
+@pytest.mark.parametrize(
+    (
+        "attn_mask_shape",
+        "attn_mask_dtype",
+        "expected_error",
+        "expected_message",
+    ),
+    [
+        pytest.param(
+            (8, 8),
+            torch.float32,
+            TypeError,
+            "Only boolean attention masks are supported",
+            id="dtype",
+        ),
+        pytest.param(
+            (8,),
+            torch.bool,
+            ValueError,
+            "Attention mask must be 2D, 3D or 4D",
+            id="rank",
+        ),
+    ],
+)
+def test_scaled_dot_product_rejects_invalid_masks_without_strict_mode(
+    attn_mask_shape: tuple[int, ...],
+    attn_mask_dtype: torch.dtype,
+    expected_error: type[Exception],
+    expected_message: str,
+    make_qkv: MakeQKV,
+) -> None:
+    """Checks that mask dtype and rank validation cannot be disabled."""
+    query, key, value = make_qkv()
+    attn_mask = torch.zeros(attn_mask_shape, dtype=attn_mask_dtype)
+    attention = ScaledDotProductAttention(strict_mode=False)
+
+    with pytest.raises(expected_error, match=expected_message):
+        attention(
+            query=query,
+            key=key,
+            value=value,
+            attn_mask=attn_mask,
+        )

--- a/tests/test_scaled_dot_product.py
+++ b/tests/test_scaled_dot_product.py
@@ -478,3 +478,34 @@ def test_scaled_dot_product_rejects_invalid_masks_without_strict_mode(
             value=value,
             attn_mask=attn_mask,
         )
+
+
+@pytest.mark.parametrize(
+    "attn_mask_shape",
+    [
+        pytest.param((4, 5), id="2d-query-length"),
+        pytest.param((3, 3, 5), id="3d-batch-size"),
+        pytest.param((2, 3, 3, 5), id="4d-head-count"),
+    ],
+)
+def test_scaled_dot_product_rejects_invalid_mask_shapes_in_strict_mode(
+    attn_mask_shape: tuple[int, ...],
+    make_qkv: MakeQKV,
+) -> None:
+    """Checks exact mask dimensions when strict validation is enabled."""
+    query, key, value = make_qkv(
+        batch_size=2,
+        num_heads=4,
+        num_queries=3,
+        num_keys=5,
+    )
+    attn_mask = torch.zeros(attn_mask_shape, dtype=torch.bool)
+    attention = ScaledDotProductAttention(strict_mode=True)
+
+    with pytest.raises(ValueError, match="Invalid mask shape"):
+        attention(
+            query=query,
+            key=key,
+            value=value,
+            attn_mask=attn_mask,
+        )

--- a/tests/test_scaled_dot_product.py
+++ b/tests/test_scaled_dot_product.py
@@ -101,15 +101,28 @@ def test_sdpa_backend_matches_torch_scaled_dot_product_attention(
     torch.testing.assert_close(out, expected_out)
 
 
-def test_sdpa_backend_matches_einsum_backend_with_explicit_mask(
+@pytest.mark.parametrize(
+    "attn_mask_shape",
+    [
+        (4, 4),
+        (2, 4, 4),
+        (2, 1, 4, 4),
+        (2, 3, 4, 4),
+    ],
+)
+def test_scaled_dot_product_supports_mask_broadcasting(
+    attn_mask_shape: tuple[int, ...],
     make_qkv: MakeQKV,
 ) -> None:
-    """Checks that explicit masks have matching semantics across backends."""
-    query, key, value = make_qkv(batch_size=2, num_heads=3)
-    num_queries = query.shape[-2]
-    num_keys = key.shape[-2]
-    attn_mask = torch.zeros(num_queries, num_keys, dtype=torch.bool)
-    attn_mask[:, -1] = True
+    """Checks supported mask shapes and semantics across both backends."""
+    query, key, value = make_qkv(
+        batch_size=2,
+        num_heads=3,
+        num_queries=4,
+        num_keys=4,
+    )
+    attn_mask = torch.zeros(attn_mask_shape, dtype=torch.bool)
+    attn_mask[..., -1] = True
 
     einsum_attention = ScaledDotProductAttention(
         is_causal=False,

--- a/tests/test_scaled_dot_product.py
+++ b/tests/test_scaled_dot_product.py
@@ -6,10 +6,10 @@ from adlers.shared import ScaledDotProductAttention
 from tests._typing import MakeQKV
 
 
-@pytest.mark.parametrize("use_mask", [False, True])
+@pytest.mark.parametrize("is_causal", [False, True])
 @pytest.mark.parametrize("output_attention_scores", [False, True])
 def test_scaled_dot_product(
-    use_mask: bool,
+    is_causal: bool,
     output_attention_scores: bool,
     make_qkv: MakeQKV,
 ) -> None:
@@ -29,7 +29,7 @@ def test_scaled_dot_product(
     )
 
     attention = ScaledDotProductAttention(
-        use_mask=use_mask,
+        is_causal=is_causal,
         dropout_rate=0.0,
         backend="einsum",
         output_attention_scores=output_attention_scores,
@@ -37,12 +37,22 @@ def test_scaled_dot_product(
         custom_scale_factor=None,
     )
 
-    if use_mask:
+    if is_causal:
         # let it generate the triangular mask on its own
-        out, weights = attention(query=query, key=key, value=value, mask=None)
+        out, weights = attention(
+            query=query,
+            key=key,
+            value=value,
+            attn_mask=None,
+        )
         assert torch.isfinite(out).all()
     else:
-        out, weights = attention(query=query, key=key, value=value, mask=None)
+        out, weights = attention(
+            query=query,
+            key=key,
+            value=value,
+            attn_mask=None,
+        )
 
     assert out.shape == (batch_size, num_heads, num_queries, head_dim)
 
@@ -55,16 +65,16 @@ def test_scaled_dot_product(
         )
 
 
-@pytest.mark.parametrize("use_mask", [False, True])
+@pytest.mark.parametrize("is_causal", [False, True])
 def test_sdpa_backend_matches_torch_scaled_dot_product_attention(
-    use_mask: bool,
+    is_causal: bool,
     make_qkv: MakeQKV,
 ) -> None:
     """Checks that the SDPA backend matches PyTorch's native implementation."""
     query, key, value = make_qkv()
 
     attention = ScaledDotProductAttention(
-        use_mask=use_mask,
+        is_causal=is_causal,
         dropout_rate=0.0,
         backend="sdpa",
         output_attention_scores=False,
@@ -72,14 +82,19 @@ def test_sdpa_backend_matches_torch_scaled_dot_product_attention(
         custom_scale_factor=None,
     )
 
-    out, weights = attention(query=query, key=key, value=value, mask=None)
+    out, weights = attention(
+        query=query,
+        key=key,
+        value=value,
+        attn_mask=None,
+    )
     expected_out = F.scaled_dot_product_attention(
         query=query,
         key=key,
         value=value,
         attn_mask=None,
         dropout_p=0.0,
-        is_causal=use_mask,
+        is_causal=is_causal,
     )
 
     assert weights is None
@@ -93,11 +108,11 @@ def test_sdpa_backend_matches_einsum_backend_with_explicit_mask(
     query, key, value = make_qkv(batch_size=2, num_heads=3)
     num_queries = query.shape[-2]
     num_keys = key.shape[-2]
-    mask = torch.zeros(num_queries, num_keys, dtype=torch.bool)
-    mask[:, -1] = True
+    attn_mask = torch.zeros(num_queries, num_keys, dtype=torch.bool)
+    attn_mask[:, -1] = True
 
     einsum_attention = ScaledDotProductAttention(
-        use_mask=True,
+        is_causal=False,
         dropout_rate=0.0,
         backend="einsum",
         output_attention_scores=True,
@@ -105,7 +120,7 @@ def test_sdpa_backend_matches_einsum_backend_with_explicit_mask(
         custom_scale_factor=None,
     )
     sdpa_attention = ScaledDotProductAttention(
-        use_mask=True,
+        is_causal=False,
         dropout_rate=0.0,
         backend="sdpa",
         output_attention_scores=False,
@@ -113,19 +128,67 @@ def test_sdpa_backend_matches_einsum_backend_with_explicit_mask(
         custom_scale_factor=None,
     )
 
-    expected_out, _ = einsum_attention(
+    expected_out, expected_weights = einsum_attention(
         query=query,
         key=key,
         value=value,
-        mask=mask,
+        attn_mask=attn_mask,
     )
     out, weights = sdpa_attention(
         query=query,
         key=key,
         value=value,
-        mask=mask,
+        attn_mask=attn_mask,
     )
 
+    assert expected_weights is not None
+    assert torch.count_nonzero(expected_weights[..., -1]) == 0
+    assert weights is None
+    torch.testing.assert_close(out, expected_out)
+
+
+def test_scaled_dot_product_combines_causal_and_explicit_masks(
+    make_qkv: MakeQKV,
+) -> None:
+    """Checks that explicit restrictions are added to causal masking."""
+    query, key, value = make_qkv(
+        batch_size=1,
+        num_heads=1,
+        num_queries=4,
+        num_keys=4,
+    )
+    attn_mask = torch.zeros(4, 4, dtype=torch.bool)
+    attn_mask[2:, 0] = True
+    causal_mask = torch.triu(torch.ones_like(attn_mask), diagonal=1)
+    combined_mask = causal_mask | attn_mask
+    einsum_attention = ScaledDotProductAttention(
+        is_causal=True,
+        backend="einsum",
+        output_attention_scores=True,
+    )
+    sdpa_attention = ScaledDotProductAttention(
+        is_causal=True,
+        backend="sdpa",
+        output_attention_scores=False,
+    )
+
+    expected_out, expected_weights = einsum_attention(
+        query=query,
+        key=key,
+        value=value,
+        attn_mask=attn_mask,
+    )
+    out, weights = sdpa_attention(
+        query=query,
+        key=key,
+        value=value,
+        attn_mask=attn_mask,
+    )
+
+    assert expected_weights is not None
+    assert (
+        torch.count_nonzero(expected_weights.masked_select(combined_mask)) == 0
+    )
     assert weights is None
     torch.testing.assert_close(out, expected_out)
 
@@ -142,7 +205,7 @@ def test_sdpa_backend_rejects_attention_scores() -> None:
 def test_scaled_dot_product_rejects_invalid_backend() -> None:
     """Checks that unknown attention backends fail fast."""
     with pytest.raises(ValueError, match="Invalid backend"):
-        ScaledDotProductAttention(backend="supermaxx")
+        ScaledDotProductAttention(backend="supermaxx")  # type: ignore[arg-type]
 
 
 def test_scaled_dot_product_requires_boolean_mask(
@@ -150,13 +213,22 @@ def test_scaled_dot_product_requires_boolean_mask(
 ) -> None:
     """Checks that attention masks must use torch.bool dtype."""
     query, key, value = make_qkv()
-    mask = torch.zeros(query.shape[-2], key.shape[-2], dtype=torch.float32)
+    attn_mask = torch.zeros(
+        query.shape[-2],
+        key.shape[-2],
+        dtype=torch.float32,
+    )
     attention = ScaledDotProductAttention(
-        use_mask=True,
+        is_causal=False,
         strict_mode=True,
     )
 
     with pytest.raises(
         TypeError, match="Only boolean attention masks are supported"
     ):
-        attention(query=query, key=key, value=value, mask=mask)
+        attention(
+            query=query,
+            key=key,
+            value=value,
+            attn_mask=attn_mask,
+        )

--- a/tests/test_scaled_dot_product.py
+++ b/tests/test_scaled_dot_product.py
@@ -394,6 +394,59 @@ def test_scaled_dot_product_combines_causal_and_explicit_masks(
     torch.testing.assert_close(out, expected_out)
 
 
+def test_scaled_dot_product_backends_zero_fully_masked_query_rows(
+    make_qkv: MakeQKV,
+) -> None:
+    """Checks that fully masked query rows produce zeros across backends."""
+    batch_size = 2
+    num_heads = 4
+    num_queries = 3
+    num_keys = 5
+    fully_masked_query_index = 1
+    query, key, value = make_qkv(
+        batch_size=batch_size,
+        num_heads=num_heads,
+        num_queries=num_queries,
+        num_keys=num_keys,
+    )
+    attn_mask = torch.zeros(num_queries, num_keys, dtype=torch.bool)
+    attn_mask[fully_masked_query_index, :] = True
+    einsum_attention = ScaledDotProductAttention(
+        backend="einsum",
+        output_attention_scores=True,
+    )
+    sdpa_attention = ScaledDotProductAttention(backend="sdpa")
+
+    einsum_output, einsum_weights = einsum_attention(
+        query=query,
+        key=key,
+        value=value,
+        attn_mask=attn_mask,
+    )
+    sdpa_output, sdpa_weights = sdpa_attention(
+        query=query,
+        key=key,
+        value=value,
+        attn_mask=attn_mask,
+    )
+
+    assert einsum_weights is not None
+    assert sdpa_weights is None
+    torch.testing.assert_close(
+        einsum_weights[..., fully_masked_query_index, :],
+        torch.zeros_like(einsum_weights[..., fully_masked_query_index, :]),
+    )
+    torch.testing.assert_close(
+        einsum_output[..., fully_masked_query_index, :],
+        torch.zeros_like(einsum_output[..., fully_masked_query_index, :]),
+    )
+    torch.testing.assert_close(
+        sdpa_output[..., fully_masked_query_index, :],
+        torch.zeros_like(sdpa_output[..., fully_masked_query_index, :]),
+    )
+    torch.testing.assert_close(einsum_output, sdpa_output)
+
+
 def test_sdpa_backend_rejects_attention_scores() -> None:
     """Checks that SDPA rejects unsupported attention score output."""
     with pytest.raises(ValueError, match="does not support"):

--- a/tests/test_scaled_dot_product.py
+++ b/tests/test_scaled_dot_product.py
@@ -177,6 +177,54 @@ def test_scaled_dot_product_supports_cpu_bfloat16_autocast(
         assert weights is None
 
 
+@pytest.mark.parametrize("backend", ["einsum", "sdpa"])
+def test_scaled_dot_product_supports_torch_compile_fullgraph_capture(
+    backend: AttentionBackend,
+    make_qkv: MakeQKV,
+) -> None:
+    """Checks full-graph torch.compile capture for every backend."""
+    query, key, value = make_qkv(
+        batch_size=2,
+        num_heads=4,
+        num_queries=3,
+        num_keys=5,
+    )
+    attn_mask = torch.zeros(3, 5, dtype=torch.bool)
+    attn_mask[:, -1] = True
+    output_attention_scores = backend == "einsum"
+    attention = ScaledDotProductAttention(
+        backend=backend,
+        output_attention_scores=output_attention_scores,
+    )
+    compiled_attention = torch.compile(
+        model=attention,
+        backend="eager",
+        fullgraph=True,
+    )
+
+    expected_output, expected_weights = attention(
+        query=query,
+        key=key,
+        value=value,
+        attn_mask=attn_mask,
+    )
+    output, weights = compiled_attention(
+        query=query,
+        key=key,
+        value=value,
+        attn_mask=attn_mask,
+    )
+
+    torch.testing.assert_close(output, expected_output)
+    if output_attention_scores:
+        assert weights is not None
+        assert expected_weights is not None
+        torch.testing.assert_close(weights, expected_weights)
+    else:
+        assert weights is None
+        assert expected_weights is None
+
+
 @pytest.mark.parametrize(
     "attn_mask_shape",
     [

--- a/uv.lock
+++ b/uv.lock
@@ -18,7 +18,7 @@ conflicts = [[
 
 [[package]]
 name = "adlers"
-version = "0.3.0"
+version = "0.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "numpy" },


### PR DESCRIPTION
## Summary

This PR settles the shared attention behavior before I start adding more mechanisms.

The main changes are:

- Replaced `use_mask` with `is_causal`.
- Renamed the forward mask argument to `attn_mask`.
- Made supplied masks work independently of causal masking.
- Combined supplied and causal masks when both are used.
- Preserved compact mask shapes instead of expanding every mask across batches and heads.
- Added support for cross-attention with different query and key lengths.
- Added shape validation for query, key, value, and attention masks.
- Made fully masked query rows return zeros in both backends.
- Verified evaluation dropout, CPU bfloat16 autocast, `torch.compile`, and
  `torch.export`.

Boolean mask semantics remain unchanged: `True` means masked out.

## Breaking changes

- `use_mask` is now `is_causal`.
- The forward argument `mask` is now `attn_mask`.